### PR TITLE
Sftw 3821 amplicon optimisation

### DIFF
--- a/modules/local/common.nf
+++ b/modules/local/common.nf
@@ -39,6 +39,8 @@ process mosdepth {
     int mosdepth_extra_threads = task.cpus - 1
     ref_id = ref_id ?: ""
     """
+    mosdepth_options=(-t $mosdepth_extra_threads -n)
+
     REF_ID="$ref_id"
     # get ref IDs and lengths with `samtools idxstats`
     samtools idxstats input.bam > idxstats
@@ -46,15 +48,19 @@ process mosdepth {
     # if `ref_id` was `null`, assume that there was only one reference and look up its
     # ID from the idxstats
     if [ -z "\$REF_ID" ]; then
-        REF_ID=\$(head -n1 idxstats | cut -f1)
-        if [[ \$REF_ID = '*' ]]; then
+        first_contig=\$(head -n1 idxstats | cut -f1)
+        if [[ \$first_contig = '*' ]]; then
             echo "QUITTING: Only unmapped reads in 'input.bam'."
             exit 0
         fi
-    fi
 
-    # get the length of the reference
-    REF_LENGTH=\$(grep -w "\$REF_ID" idxstats | cut -f2)
+        # Use the longest reference to determine window length
+        REF_LENGTH=\$(cat idxstats | cut -f2 | sort -n | tail -1)
+    else
+        # get the length of the reference
+        REF_LENGTH=\$(grep -w "\$REF_ID" idxstats | cut -f2)
+        mosdepth_options+=(-c "\$REF_ID")
+    fi
 
     # calculate the corresponding window length (check `REF_LENGTH` first because
     # `expr a / b` returns non-zero exit code when `a < b`)
@@ -63,9 +69,11 @@ process mosdepth {
         window_length=\$(expr \$REF_LENGTH / $n_windows)
     fi
 
+    mosdepth_options+=(-b \$window_length)
+
     # get the depths (we could add `-x`, but this loses a lot of detail from the depth
     # curves)
-    mosdepth -t $mosdepth_extra_threads -b \$window_length -n depth input.bam
+    mosdepth "\${mosdepth_options[@]}" depth input.bam
     """
 }
 

--- a/modules/local/common.nf
+++ b/modules/local/common.nf
@@ -97,12 +97,12 @@ process medakaConsensus {
     cpus Math.min(params.threads, 2)
     memory "8 GB"
     input:
-        tuple val(meta), path("input.bam"), path("input.bam.bai"), val(regions)
+        tuple val(meta), path("input.bam"), path("input.bam.bai"), val(region)
         val type
     output: tuple val(meta), path("consensus_probs.hdf")
     script:
     // run on a particular region if specified
-    String region_arg = regions ? "--regions ${regions.join(' ')}" : ""
+    String region_arg = region ? "--regions '$region'" : ""
     // we use `params.override_basecaller_cfg` if present; otherwise use
     // `meta.basecall_models[0]` (there should only be one value in the list because
     // we're running ingress with `allow_multiple_basecall_models: false`; note that

--- a/modules/local/common.nf
+++ b/modules/local/common.nf
@@ -65,7 +65,7 @@ process mosdepth {
 
     # get the depths (we could add `-x`, but this loses a lot of detail from the depth
     # curves)
-    mosdepth -t $mosdepth_extra_threads -b \$window_length -n -c "\$REF_ID" depth input.bam
+    mosdepth -t $mosdepth_extra_threads -b \$window_length -n depth input.bam
     """
 }
 
@@ -89,12 +89,12 @@ process medakaConsensus {
     cpus Math.min(params.threads, 2)
     memory "8 GB"
     input:
-        tuple val(meta), path("input.bam"), path("input.bam.bai"), val(region)
+        tuple val(meta), path("input.bam"), path("input.bam.bai"), val(regions)
         val type
     output: tuple val(meta), path("consensus_probs.hdf")
     script:
     // run on a particular region if specified
-    String region_arg = region ? "--regions '$region'" : ""
+    String region_arg = regions ? "--regions ${regions.join(' ')}" : ""
     // we use `params.override_basecaller_cfg` if present; otherwise use
     // `meta.basecall_models[0]` (there should only be one value in the list because
     // we're running ingress with `allow_multiple_basecall_models: false`; note that

--- a/modules/local/common.nf
+++ b/modules/local/common.nf
@@ -45,8 +45,8 @@ process mosdepth {
     # get ref IDs and lengths with `samtools idxstats`
     samtools idxstats input.bam > idxstats
 
-    # if `ref_id` was `null`, assume that there was only one reference and look up its
-    # ID from the idxstats
+    # if `ref_id` was `null` or `false`, use the longest reference to determine
+    # window length
     if [ -z "\$REF_ID" ]; then
         first_contig=\$(head -n1 idxstats | cut -f1)
         if [[ \$first_contig = '*' ]]; then
@@ -54,7 +54,6 @@ process mosdepth {
             exit 0
         fi
 
-        # Use the longest reference to determine window length
         REF_LENGTH=\$(cat idxstats | cut -f2 | sort -n | tail -1)
     else
         # get the length of the reference

--- a/modules/local/variant-calling.nf
+++ b/modules/local/variant-calling.nf
@@ -231,7 +231,7 @@ workflow pipeline {
         // combination)
         ch_medaka_consensus_probs = medakaConsensus(
             // join with and transpose on the list of sanitized IDs for each sample
-            downsampleBAMforMedaka.out | join(ch_sanitized_ids) | transpose(by: 3),
+            downsampleBAMforMedaka.out | join(ch_sanitized_ids),
             "variant",
         ) | groupTuple
 
@@ -245,7 +245,7 @@ workflow pipeline {
 
         // run mosdepth on each sample--amplicon combination
         mosdepth(
-            alignReads.out | join(ch_sanitized_ids) | transpose(by: 3),
+            alignReads.out | join(ch_sanitized_ids),
             params.number_depth_windows
         )
         // concat the depth files for each sample

--- a/modules/local/variant-calling.nf
+++ b/modules/local/variant-calling.nf
@@ -229,11 +229,13 @@ workflow pipeline {
 
         // run medaka consensus
         if (params.split_ref)
+            // Parallelise over amplicons
             downsampleBAMforMedaka.out
                 | join(ch_sanitized_ids)
                 | transpose(by: 3)
                 | set { medakaVariantInputCh }
         else
+            // Process all amplicons in one go
             downsampleBAMforMedaka.out
                 | map { it + [false] }
                 | set { medakaVariantInputCh }
@@ -253,11 +255,13 @@ workflow pipeline {
         
         // Get depth of coverage
         if (params.split_ref)
+            // Parallelise over amplicons
             alignReads.out 
                 | join(ch_sanitized_ids)
                 | transpose(by: 3)
                 | set { mosdepthInputCh }
         else
+            // Process all amplicons in one go
             alignReads.out | map { it + [false] } | set { mosdepthInputCh }
 
         mosdepth(mosdepthInputCh, params.number_depth_windows)

--- a/modules/local/variant-calling.nf
+++ b/modules/local/variant-calling.nf
@@ -228,7 +228,7 @@ workflow pipeline {
         | downsampleBAMforMedaka
 
         // run medaka consensus
-        if (params.splitRef)
+        if (params.split_ref)
             downsampleBAMforMedaka.out
                 | join(ch_sanitized_ids)
                 | transpose(by: 3)
@@ -252,7 +252,7 @@ workflow pipeline {
         )
         
         // Get depth of coverage
-        if (params.splitRef)
+        if (params.split_ref)
             alignReads.out 
                 | join(ch_sanitized_ids)
                 | transpose(by: 3)

--- a/nextflow.config
+++ b/nextflow.config
@@ -50,6 +50,7 @@ params {
     aws_queue = null
     disable_ping = false
     threads = 4
+    splitRef = false // Run amplicons in parallel for coverage and variant calling
 
     // schema etc.
     monochrome_logs = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,6 +20,7 @@ params {
     analyse_unclassified = false
     combine_results = false
     igv = false
+    split_ref = false
 
     // filtering + downsampling args
     min_read_length = 300
@@ -50,7 +51,6 @@ params {
     aws_queue = null
     disable_ping = false
     threads = 4
-    splitRef = false // Run amplicons in parallel for coverage and variant calling
 
     // schema etc.
     monochrome_logs = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -269,6 +269,13 @@
                     "default": false,
                     "description": "Enable to prevent sending a workflow ping."
                 },
+                "split_ref": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Split reference",
+                    "description": "Run amplicons in parallel for coverage and variant calling.",
+                    "help_text": "Processing each amplicon in parallel can lead to performance bottlenecks due to the large number of jobs submitted to the scheduler."
+                },
                 "help": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
# Addresses
[SFTW-3845](https://labgenius.atlassian.net/browse/SFTW-3845) (part 1)

# Key Changes
The workflow has now been optimised to drastically reduce the number of jobs submitted to the Batch scheduler. See [SFTW-3821](https://labgenius.atlassian.net/browse/SFTW-3821) for more details.

* `modules/local/variant-calling.nf`:
    * Implemented a new param, `split_ref`, which controls whether the coverage (mosdepth) and variant calling (medakaVariant) are run separately on each amplicon in parallel.
 * `modules/local/common.nf`:
     *  modified the `mosdepth` process such that the window size will be determined from the largest amplicon when `ref_id` is set to `null` or `false`. Note that this means that the coverage profiles may look slightly different depending on whether or not split_ref is used, but the meaning of the results is exactly the same (see report HTML files on See [SFTW-3845](https://labgenius.atlassian.net/browse/SFTW-3845) as an example).

# Tests

The example test was run with and without the `--split_ref` option. The output was indistinguishable between the two runs and the number of jobs was as expected in each case. See [SFTW-3845](https://labgenius.atlassian.net/browse/SFTW-3845) for wf-amplicon  HTML report and Nextflow timeline files.


[SFTW-3845]: https://labgenius.atlassian.net/browse/SFTW-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFTW-3821]: https://labgenius.atlassian.net/browse/SFTW-3821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFTW-3845]: https://labgenius.atlassian.net/browse/SFTW-3845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ