### PR TITLE
SFTW-3983 / 8 CPUs for report

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -190,7 +190,7 @@ process concatTSVs {
 process makeReport {
     label "wfamplicon"
     publishDir "${params.out_dir}", mode: 'copy', pattern: "wf-amplicon-report.html"
-    cpus 1
+    cpus 8
     memory "8 GB"
     input:
         path "data/*"


### PR DESCRIPTION
Increasing number of CPUs in `makeReport` process from 1 to 8.

May not result in performance benefit but worth a try!